### PR TITLE
#572688: Re-enable SSL certificate checks.

### DIFF
--- a/mendix-platform-sdk.ts
+++ b/mendix-platform-sdk.ts
@@ -388,9 +388,7 @@ export class PlatformSdkClient {
 			headers: {
 				'Content-Type': 'text/xml;charset=UTF-8'
 			},
-			mixin: {
-				rejectUnauthorized: false
-			},
+			mixin: {},
 			entity: payload
 		};
 	}


### PR DESCRIPTION
Note: the tests project needs a small fix as well, will push it once I have access.

Add to the top of the tests.ts file:
`process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";`