### PR TITLE
#599332: Upgrade peer dependency tot modelsdk to ^1.0.1, for release 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendixplatformsdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "mendix-platform-sdk.js",
   "typings": "mendix-platform-sdk",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "tslint": "^2.5.1"
   },
   "peerDependencies": {
-    "mendixmodelsdk": "1.0.0"
+    "mendixmodelsdk": "^1.0.0"
   }
 }


### PR DESCRIPTION
Using ^ instead of ~ as suggested by Erik vd Pol. Please review.