### PR TITLE
#607830: Port to Model SDK 1.0.2 and rely on default endpoint of Model SDK

### DIFF
--- a/mendix-platform-sdk.ts
+++ b/mendix-platform-sdk.ts
@@ -94,7 +94,6 @@ export class MendixSdkClient {
 	private _modelSdkClient: ModelSdkClient;
 	private _options: SdkOptions;
 
-	private static DEFAULT_MODELAPI_ENDPOINT = `https://model-api.cfapps.io`;
 	private static DEFAULT_PROJECTSAPI_ENDPOINT = `https://sprintr.home.mendix.com`;
 
 	private static DEFAULT_POLL_DELAY = 1000;
@@ -128,10 +127,15 @@ export class MendixSdkClient {
 			throw new Error(`Incomplete credentials`);
 		}
 
-		this._modelSdkClient = Model.createSdkClient({
-			credentials: credentials,
-			endPoint: modelApiEndpoint ? modelApiEndpoint : MendixSdkClient.DEFAULT_MODELAPI_ENDPOINT
-		});
+		let connectionConfig: configuration.ISdkConfig = {
+			credentials: credentials
+		};
+
+		if (!(_.isEmpty(modelApiEndpoint))) {
+			connectionConfig["endPoint"] = modelApiEndpoint;
+		}
+
+		this._modelSdkClient = Model.createSdkClient(connectionConfig);
 
 		this._platformSdkClient = new PlatformSdkClient(this, username, apikey,
 			projectsApiEndpoint ? projectsApiEndpoint : MendixSdkClient.DEFAULT_PROJECTSAPI_ENDPOINT);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mendixplatformsdk",
   "version": "1.0.2",
-  "description": "",
+  "description": "Mendix Platform SDK",
   "main": "mendix-platform-sdk.js",
   "typings": "mendix-platform-sdk",
   "scripts": {
@@ -12,7 +12,10 @@
     "doc": "typedoc --module commonjs --target es5 --out doc mendix-platform-sdk.ts",
     "lint": "tslint mendix-platform-sdk.ts test/test.ts test/smoke-test.ts"
   },
-  "author": "Mendix BV",
+  "author": {
+    "name": "Mendix Platform",
+    "email": "platform@mendix.com"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mendixplatformsdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "main": "mendix-platform-sdk.js",
   "typings": "mendix-platform-sdk",
@@ -37,6 +37,6 @@
     "tslint": "^2.5.1"
   },
   "peerDependencies": {
-    "mendixmodelsdk": "^1.0.0"
+    "mendixmodelsdk": "^1.0.2"
   }
 }


### PR DESCRIPTION
Please review but don't merge until mendixmodelsdk 1.0.2 is on npm.
Also, I suspect nock fixtures need to be updated because we're no longer sending an explicit model API endpoint over the line. Let's discuss later.